### PR TITLE
making things Sendable to use with async - SIMDScalar isn't

### DIFF
--- a/Sources/Voxels/VoxelStorage/VoxelArray.swift
+++ b/Sources/Voxels/VoxelStorage/VoxelArray.swift
@@ -1,5 +1,5 @@
 /// A collection of voxels backed by an array.
-public struct VoxelArray<T>: VoxelWritable {
+public struct VoxelArray<T: Sendable>: VoxelWritable, Sendable {
     var _contents: [T]
     public let edgeSize: Int
     public var bounds: VoxelBounds

--- a/Sources/Voxels/VoxelStorage/VoxelHash.swift
+++ b/Sources/Voxels/VoxelStorage/VoxelHash.swift
@@ -1,7 +1,7 @@
 /// A collection of voxels backed by a hash table.
 ///
 /// Useful for sparse voxel collections.
-public struct VoxelHash<T>: VoxelWritable {
+public struct VoxelHash<T: Sendable>: VoxelWritable, Sendable {
     var _contents: [VoxelIndex: T]
     public var bounds: VoxelBounds
     let defaultVoxel: T?

--- a/Tests/VoxelsTests/VoxelScaleTests.swift
+++ b/Tests/VoxelsTests/VoxelScaleTests.swift
@@ -54,7 +54,9 @@ class VoxelScaleTests: XCTestCase {
     func testMappingFloatIntoVoxelIndex() throws {
         let scale = VoxelScale<Float>()
         XCTAssertEqual(scale.cubeSize, 1)
-        XCTAssertEqual(scale.origin, SIMD3<Float>(0, 0, 0))
+        XCTAssertEqual(scale.origin.0, 0)
+        XCTAssertEqual(scale.origin.1, 0)
+        XCTAssertEqual(scale.origin.2, 0)
 
         let sphereSDF = SDF.sphere(radius: 5)
 


### PR DESCRIPTION
Making a lot more the structs in Voxels sendable to work with Swift's async/await.
- SIMDScalar apparently isn't Sendable
