### PR TITLE
removing safety guards on indexing into VoxelArray

### DIFF
--- a/Sources/Voxels/SampleMeshData.swift
+++ b/Sources/Voxels/SampleMeshData.swift
@@ -15,7 +15,7 @@ public enum SampleMeshData {
             let voxelIndex = try samples.bounds.delinearize(i)
             let position: SIMD3<Float> = into_domain(array_dim: 32, voxelIndex)
             let value = sphereSDF.valueAt(position)
-            try samples.set(voxelIndex, newValue: value)
+            samples.set(voxelIndex, newValue: value)
         }
         return samples
     }

--- a/Sources/Voxels/VoxelBounds.swift
+++ b/Sources/Voxels/VoxelBounds.swift
@@ -1,3 +1,5 @@
+import IssueReporting
+
 /// The coordinate bounds of a set of voxels.
 public struct VoxelBounds: Sendable {
     public let min: VoxelIndex
@@ -150,6 +152,9 @@ extension VoxelBounds: StrideIndexable {
 
     @inline(__always)
     public func _unchecked_delinearize(_ strideIndex: Int) -> VoxelIndex {
+        if strideIndex < 0 || strideIndex >= size {
+            reportIssue("stride index out of bounds: \(strideIndex)")
+        }
         let xDistance = self.max.x - self.min.x // 1
         let yDistance = self.max.y - self.min.y // 2
         let zDistance = self.max.z - self.min.z // 3

--- a/Sources/Voxels/VoxelStorage/VoxelArray+updating.swift
+++ b/Sources/Voxels/VoxelStorage/VoxelArray+updating.swift
@@ -1,15 +1,15 @@
 public extension VoxelArray {
-    mutating func updating(with voxels: VoxelHash<T>) throws {
+    mutating func updating(with voxels: VoxelHash<T>) {
         for idx in voxels._contents.keys {
             if let voxelValue = voxels[idx] {
-                try set(idx, newValue: voxelValue)
+                set(idx, newValue: voxelValue)
             }
         }
     }
 
-    mutating func updating(with voxelUpdates: [VoxelUpdate<T>]) throws {
+    mutating func updating(with voxelUpdates: [VoxelUpdate<T>]) {
         for update in voxelUpdates {
-            try set(update.index, newValue: update.value)
+            set(update.index, newValue: update.value)
         }
     }
 }

--- a/Sources/Voxels/VoxelStorage/VoxelArray.swift
+++ b/Sources/Voxels/VoxelStorage/VoxelArray.swift
@@ -1,3 +1,5 @@
+import IssueReporting
+
 /// A collection of voxels backed by an array.
 public struct VoxelArray<T: Sendable>: VoxelWritable {
     var _contents: [T]
@@ -15,13 +17,13 @@ public struct VoxelArray<T: Sendable>: VoxelWritable {
         bounds = VoxelBounds(min: VoxelIndex(0, 0, 0), max: VoxelIndex(edge - 1, edge - 1, edge - 1))
     }
 
-    public func value(_ vi: VoxelIndex) throws -> T? {
-        let stride = try bounds.linearize(vi)
+    public func value(_ vi: VoxelIndex) -> T? {
+        let stride = bounds._unchecked_linearize(vi)
         return _contents[stride]
     }
 
-    public mutating func set(_ vi: VoxelIndex, newValue: T) throws {
-        let stride = try bounds.linearize(vi)
+    public mutating func set(_ vi: VoxelIndex, newValue: T) {
+        let stride = bounds._unchecked_linearize(vi)
         _contents[stride] = newValue
     }
 

--- a/Tests/VoxelsTests/VoxelArrayTests.swift
+++ b/Tests/VoxelsTests/VoxelArrayTests.swift
@@ -12,16 +12,16 @@ class VoxelArrayTests: XCTestCase {
         }
 
         // external access
-        XCTAssertEqual(try v.value(VoxelIndex(x: 0, y: 0, z: 0)), 1)
-        XCTAssertEqual(try v.value(VoxelIndex(x: 1, y: 1, z: 1)), 1)
-        XCTAssertEqual(try v.value(VoxelIndex(x: 2, y: 2, z: 2)), 1)
+        XCTAssertEqual(v.value(VoxelIndex(x: 0, y: 0, z: 0)), 1)
+        XCTAssertEqual(v.value(VoxelIndex(x: 1, y: 1, z: 1)), 1)
+        XCTAssertEqual(v.value(VoxelIndex(x: 2, y: 2, z: 2)), 1)
 
         XCTAssertEqual(v.bounds.size, 27)
     }
 
     func testVoxelArraySequence() throws {
         var voxels = VoxelArray<Int>(edge: 3, value: 1)
-        try voxels.set(VoxelIndex(1, 1, 1), newValue: 2)
+        voxels.set(VoxelIndex(1, 1, 1), newValue: 2)
 
         let ones = voxels.filter { $0 == 1 }
         XCTAssertEqual(ones.count, 26)
@@ -30,19 +30,19 @@ class VoxelArrayTests: XCTestCase {
         XCTAssertEqual(twos.count, 1)
     }
 
-    func testVoxelOutOfBoundsAccess() throws {
-        let voxels = VoxelArray<Int>(edge: 3, value: 1)
-        XCTAssertThrowsError(try voxels.value(VoxelIndex(x: -1, y: 0, z: 0)))
-
-        XCTAssertThrowsError(try voxels.value(VoxelIndex(x: 2, y: 2, z: 3)))
-    }
+//    func testVoxelOutOfBoundsAccess() throws {
+//        let voxels = VoxelArray<Int>(edge: 3, value: 1)
+//        XCTAssertThrowsError(try voxels.value(VoxelIndex(x: -1, y: 0, z: 0)))
+//
+//        XCTAssertThrowsError(try voxels.value(VoxelIndex(x: 2, y: 2, z: 3)))
+//    }
 
     func testApplyingVoxelUpdate() throws {
         let index = VoxelIndex(0, 1, 1)
         var voxels = VoxelArray<Int>(edge: 3, value: 1)
 
         let update = VoxelUpdate(index: index, value: 5)
-        try voxels.updating(with: [update])
+        voxels.updating(with: [update])
 
         XCTAssertEqual(voxels[index], 5)
     }
@@ -54,7 +54,7 @@ class VoxelArrayTests: XCTestCase {
         var updateSet = VoxelHash<Int>()
         updateSet[index] = 5
 
-        try voxels.updating(with: updateSet)
+        voxels.updating(with: updateSet)
 
         XCTAssertEqual(voxels[index], 5)
     }


### PR DESCRIPTION
removing `try` guardrails on VoxelArray