### PR TITLE
adding instance functions for manhattan neighbors 1 and 2

### DIFF
--- a/Sources/Voxels/VoxelIndex+neighbors.swift
+++ b/Sources/Voxels/VoxelIndex+neighbors.swift
@@ -1,4 +1,41 @@
 public extension VoxelIndex {
+    /// Returns the manhattan neighbors with a distance of one from this index.
+    @inlinable
+    func manhattan_1_neighbors() -> [VoxelIndex] {
+        [
+            adding(VoxelIndex(1, 0, 0)),
+            adding(VoxelIndex(-1, 0, 0)),
+            adding(VoxelIndex(0, 1, 0)),
+            adding(VoxelIndex(0, -1, 0)),
+            adding(VoxelIndex(0, 0, 1)),
+            adding(VoxelIndex(0, 0, -1)),
+        ]
+    }
+
+    /// Returns the manhattan neighbors with a distance of two from this index.
+    @inlinable
+    func manhattan_2_neighbors() -> [VoxelIndex] {
+        var neighbors: [VoxelIndex] = []
+        for i in x - 1 ... x + 1 {
+            for j in y - 1 ... y + 1 {
+                for k in z - 1 ... z + 1 {
+                    let new = VoxelIndex(i, j, k)
+                    let distance = VoxelIndex.manhattan_distance(from: self, to: new)
+                    if distance == 1 || distance == 2 {
+                        neighbors.append(new)
+                    }
+                }
+            }
+        }
+        neighbors.append(adding(VoxelIndex(2, 0, 0)))
+        neighbors.append(adding(VoxelIndex(-2, 0, 0)))
+        neighbors.append(adding(VoxelIndex(0, 2, 0)))
+        neighbors.append(adding(VoxelIndex(0, -2, 0)))
+        neighbors.append(adding(VoxelIndex(0, 0, 2)))
+        neighbors.append(adding(VoxelIndex(0, 0, -2)))
+        return neighbors
+    }
+
     static func manhattan_distance(from: VoxelIndex, to: VoxelIndex) -> Int {
         abs(from.x - to.x) + abs(from.y - to.y) + abs(from.z - to.z)
     }

--- a/Tests/VoxelsTests/VoxelIndexTests.swift
+++ b/Tests/VoxelsTests/VoxelIndexTests.swift
@@ -14,14 +14,6 @@ class VoxelIndexTests: XCTestCase {
         XCTAssertNotNil(VoxelIndex(ijk))
     }
 
-//    func testFailingInitializer() throws {
-//        // precondition failures
-//        XCTAssertThrowsError(VoxelIndex([]))
-//        XCTAssertThrowsError(VoxelIndex([0]))
-//        XCTAssertThrowsError(VoxelIndex([0,1]))
-//        XCTAssertThrowsError(VoxelIndex([0,1,2,3]))
-//    }
-
     func testIndexComparable() throws {
         XCTAssertTrue(VoxelIndex(0, 0, 0) < VoxelIndex(2, 2, 2))
         XCTAssertFalse(VoxelIndex(0, 0, 0) > VoxelIndex(2, 2, 2))
@@ -73,6 +65,26 @@ class VoxelIndexTests: XCTestCase {
 
         let neighbors = try VoxelIndex.neighbors(distance: 0, origin: VoxelIndex(2, 2, 2), voxels: fiveByFive, strategy: .raw)
         XCTAssertEqual(neighbors.count, 1)
+    }
+
+    func testNeighbors1() throws {
+        let index = VoxelIndex((12, 5, 1))
+        let neighbors = index.manhattan_1_neighbors()
+        XCTAssertEqual(neighbors.count, 6)
+        for n in neighbors {
+            XCTAssertEqual(VoxelIndex.manhattan_distance(from: index, to: n), 1)
+        }
+    }
+
+    func testNeighbors2() throws {
+        let index = VoxelIndex((2, 2, 2))
+        let neighbors = index.manhattan_2_neighbors()
+        XCTAssertEqual(neighbors.count, 24)
+        for n in neighbors {
+            let distance = VoxelIndex.manhattan_distance(from: index, to: n)
+            // print("distance from \(index) to \(n) is \(distance)")
+            XCTAssertTrue(distance <= 2)
+        }
     }
 
     func testBuiltins() throws {


### PR DESCRIPTION
Finding it useful to have access to a quick set of Manhattan distance 1 and 2 (Von Neuman) neighbors